### PR TITLE
Initial implementation of `AllowRestrictedCustomActions` statement.

### DIFF
--- a/k9policy/interface.md
+++ b/k9policy/interface.md
@@ -5,6 +5,9 @@
 |------|-------------|:----:|:-----:|:-----:|
 | allow_administer_resource_arns | The list of fully-qualified AWS IAM ARNs authorized to administer this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-* | list | `<list>` | no |
 | allow_administer_resource_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | string | `ArnEquals` | no |
+| allow_custom_actions | A custom list of S3 API actions to authorize ARNs listed in `allow_custom_actions_arns` to execute against this bucket. | list | `<list>` | no |
+| allow_custom_actions_arns | The list of fully-qualified AWS IAM ARNs authorized to execute the custom actions against this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-* | list | `<list>` | no |
+| allow_custom_arns_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | string | `ArnEquals` | no |
 | allow_delete_data_arns | The list of fully-qualified AWS IAM ARNs authorized to delete data in this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-* | list | `<list>` | no |
 | allow_delete_data_test | The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike' | string | `ArnEquals` | no |
 | allow_read_data_arns | The list of fully-qualified AWS IAM ARNs authorized to read data in this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-* | list | `<list>` | no |

--- a/k9policy/interface.tf
+++ b/k9policy/interface.tf
@@ -51,6 +51,25 @@ variable "allow_delete_data_test" {
   description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
 }
 
+variable "allow_custom_actions" {
+  type        = "list"
+  # the AllowRestrictedCustomActions statement needs a valid s3 action, so default to something innocuous: s3:GetAnalyticsConfiguration
+  default     = ["s3:GetAnalyticsConfiguration"]
+  description = "A custom list of S3 API actions to authorize ARNs listed in `allow_custom_actions_arns` to execute against this bucket."
+}
+
+variable "allow_custom_actions_arns" {
+  type        = "list"
+  default     = []
+  description = "The list of fully-qualified AWS IAM ARNs authorized to execute the custom actions against this bucket. Wildcards are supported. e.g. arn:aws:iam::12345678910:user/ci or arn:aws:iam::12345678910:role/app-backend-*"
+}
+
+variable "allow_custom_arns_test" {
+  type        = "string"
+  default     = "ArnEquals"
+  description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
+}     
+
 output "policy_json" {
   value = "${data.aws_iam_policy_document.bucket_policy.json}"
 }

--- a/k9policy/interface.tf
+++ b/k9policy/interface.tf
@@ -52,7 +52,8 @@ variable "allow_delete_data_test" {
 }
 
 variable "allow_custom_actions" {
-  type        = "list"
+  type = "list"
+
   # the AllowRestrictedCustomActions statement needs a valid s3 action, so default to something innocuous: s3:GetAnalyticsConfiguration
   default     = ["s3:GetAnalyticsConfiguration"]
   description = "A custom list of S3 API actions to authorize ARNs listed in `allow_custom_actions_arns` to execute against this bucket."
@@ -68,7 +69,7 @@ variable "allow_custom_arns_test" {
   type        = "string"
   default     = "ArnEquals"
   description = "The IAM test to use in the policy statement condition, should be one of 'ArnEquals' (default) or 'ArnLike'"
-}     
+}
 
 output "policy_json" {
   value = "${data.aws_iam_policy_document.bucket_policy.json}"

--- a/k9policy/policy.tf
+++ b/k9policy/policy.tf
@@ -96,6 +96,28 @@ data "aws_iam_policy_document" "bucket_policy" {
   }
 
   statement {
+    sid = "AllowRestrictedCustomActions"
+
+    actions = "${var.allow_custom_actions}"
+
+    resources = [
+      "${var.s3_bucket_arn}",
+      "${var.s3_bucket_arn}/*",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "${var.allow_custom_arns_test}"
+      values   = ["${var.allow_custom_actions_arns}"]
+      variable = "aws:PrincipalArn"
+    }
+  }
+
+  statement {
     sid = "DenyEveryoneElse"
 
     effect = "Deny"

--- a/test/fixtures/minimal/minimal.tf
+++ b/test/fixtures/minimal/minimal.tf
@@ -150,13 +150,27 @@ module "declarative_privilege_policy" {
   allow_read_data_arns           = "${local.read_data_arns}"
   allow_write_data_arns          = "${local.write_data_arns}"
 
-  # unused: allow_delete_data          = [] (default)
-  # unused: allow_use_resource         = [] (default)
+  # unused: allow_delete_data_arns          = [] (default)
+  # unused: allow_use_resource_arns         = [] (default)
 }
 
 resource "local_file" "declarative_privilege_policy" {
   content  = "${module.declarative_privilege_policy.policy_json}"
   filename = "${path.module}/generated/declarative_privilege_policy.json"
+}
+
+module "declarative_custom_policy" {
+  source        = "../../../k9policy"
+  s3_bucket_arn = "${module.bucket_with_declarative_policy.bucket_arn}"
+
+  allow_administer_resource_arns = "${local.administrator_arns}"
+
+  allow_custom_actions_arns      = ["arn:aws:iam::139710491120:user/skuenzli"]
+}
+
+resource "local_file" "declarative_custom_policy" {
+  content  = "${module.declarative_privilege_policy.policy_json}"
+  filename = "${path.module}/generated/declarative_custom_policy.json"
 }
 
 variable "logical_name" {

--- a/test/fixtures/minimal/minimal.tf
+++ b/test/fixtures/minimal/minimal.tf
@@ -165,7 +165,7 @@ module "declarative_custom_policy" {
 
   allow_administer_resource_arns = "${local.administrator_arns}"
 
-  allow_custom_actions_arns      = ["arn:aws:iam::139710491120:user/skuenzli"]
+  allow_custom_actions_arns = ["arn:aws:iam::139710491120:user/skuenzli"]
 }
 
 resource "local_file" "declarative_custom_policy" {


### PR DESCRIPTION
This works, but we need to hack through TF 0.11's inability to create a nested
configuration block conditionally.  Ideally, the policy would not include a
the `AllowRestrictedCustomActions` at all if no custom actions were specified.
However, there is no way to express that directly in TF 0.11 syntax.

Keep in mind that statements must refer to valid S3 actions, so cannot be
something from `ec2:*` or `doesnotexist:*`.

As a workaround, the `AllowRestrictedCustomActions` statement defaults to what
is probably an innocuous action: `s3:GetAnalyticsConfiguration`.  The statement
does not allow any principals access by default, so no access should be granted
by the default configuration.